### PR TITLE
Fix duplicate binding error handling

### DIFF
--- a/aethc_core/src/resolver.rs
+++ b/aethc_core/src/resolver.rs
@@ -137,13 +137,17 @@ impl Cx {
 
                 if let Some(prev) = self.scopes.last().unwrap().get(name) {
                     if !prev.mutable {
-                        // ошибка уже добављена у `insert`, али за сваки случае
+                        // duplicate immutable binding – report an error and do not shadow
+                        self.errors.push(ResolveError {
+                            span: Span::default(),
+                            msg: format!("cannot reassign immutable binding `{name}`"),
+                        });
                         return Ok(hir::Stmt::Expr(rhs));
                     }
                 }
 
-                self.insert(name, Symbol{ id, ty:ty.clone(), mutable:*mutable }, Span::default());
-                Ok(hir::Stmt::Let(hir::HirLet{ id, mutable:*mutable, name:name.clone(), ty, init:rhs }))
+                self.insert(name, Symbol { id, ty: ty.clone(), mutable: *mutable }, Span::default());
+                Ok(hir::Stmt::Let(hir::HirLet { id, mutable: *mutable, name: name.clone(), ty, init: rhs }))
             }
             Expr(e) => Ok(hir::Stmt::Expr(self.lower_expr(e)?)),
             Return(opt) => Ok(hir::Stmt::Return(opt.as_ref().map(|e| self.lower_expr(e)).transpose()?)),

--- a/aethc_core/tests/borrowck_ok_err.rs
+++ b/aethc_core/tests/borrowck_ok_err.rs
@@ -19,8 +19,9 @@ fn borrowck_detects_reassignment() {
     let (hir_mod, res_errs) = resolve(&module);
 
     // Rezolver mora prijaviti tačno 1 grešku zbog x
-    assert!(
-        res_errs.is_empty(),
+    assert_eq!(
+        res_errs.len(),
+        1,
         "resolve errs: {res_errs:#?}"
     );
     // Borrow-checker ne prijavljuje dodatne greške


### PR DESCRIPTION
## Summary
- prevent redefinition of immutable locals from being silently accepted
- update test to require a resolver error when reassigning immutable binding

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_685ed5fe04308327b689ad010ca41e68