### PR TITLE
Fix comment spelling in borrowck test

### DIFF
--- a/aethc_core/tests/borrowck_ok_err.rs
+++ b/aethc_core/tests/borrowck_ok_err.rs
@@ -9,7 +9,7 @@ fn borrowck_detects_reassignment() {
     let src = r#"
         fn main() {
             let x = 1;
-            let x = 2; // dublikacija – resolve prijavljuje grešku
+            let x = 2; // duplikacija – resolve prijavljuje grešku
             let mut y = 3;
             let y = 4; // OK, prvi je bio mutable
         }


### PR DESCRIPTION
## Summary
- correct a spelling mistake in `borrowck_ok_err.rs`

## Testing
- `cargo test` *(fails: duplicate_name_error)*

------
https://chatgpt.com/codex/tasks/task_e_685ed739aba0832787f217b41e34d888