### PR TITLE
Fix string token length

### DIFF
--- a/aethc_core/src/lexer.rs
+++ b/aethc_core/src/lexer.rs
@@ -162,9 +162,9 @@ impl<'a> Lexer<'a> {
         self.bump(1); // closing quote
         if is_bytes {
             let bytes = value.into_bytes();
-            self.make_tok(TokenKind::ByteStr(bytes), self.pos - start + if is_bytes {2} else {2})
+            self.make_tok(TokenKind::ByteStr(bytes), self.pos - start + 2)
         } else {
-            self.make_tok(TokenKind::Str(value), self.pos - start + 2)
+            self.make_tok(TokenKind::Str(value), self.pos - start + 1)
         }
     }
 


### PR DESCRIPTION
## Summary
- adjust string token length

## Testing
- `cargo test` *(fails: test duplicate_name_error)*

------
https://chatgpt.com/codex/tasks/task_e_685ed74b9aa08327a8c8ecd1054d5faf