### PR TITLE
Fix test message for duplicate binding

### DIFF
--- a/aethc_core/tests/resolve_dup_name.rs
+++ b/aethc_core/tests/resolve_dup_name.rs
@@ -13,5 +13,5 @@ fn duplicate_name_error() {
     let (_hir, errs) = resolve(&module);
     assert_eq!(errs.len(), 1);
     // сада очекујемо следећу поруку:
-    assert!(errs[0].msg.contains("already defined"));
+    assert!(errs[0].msg.contains("cannot reassign immutable binding"));
 }


### PR DESCRIPTION
## Summary
- update duplicate name resolver test to expect `cannot reassign immutable binding`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685ee709d6588327bac85629e7d49c41