### PR TITLE
Remove unreachable BinOp wildcard

### DIFF
--- a/aethc_core/src/resolver.rs
+++ b/aethc_core/src/resolver.rs
@@ -382,12 +382,6 @@ impl Cx {
                             }
                         }
                     }
-                    _ => {
-                        return Err(ResolveError {
-                            span: Span::default(),
-                            msg: format!("unsupported binary operation: {:?}", op),
-                        });
-                    }
                 };
                 hir::Expr::Binary {
                     id,


### PR DESCRIPTION
## Summary
- remove the `_ =>` branch when resolving binary expressions

## Testing
- `cargo test --quiet` *(fails: resolver::tests::unary_not_bool)*

------
https://chatgpt.com/codex/tasks/task_e_6860db554228832787e3cf7a577550b3