### PR TITLE
Add Unit expression variant

### DIFF
--- a/aethc_core/src/ast.rs
+++ b/aethc_core/src/ast.rs
@@ -76,6 +76,7 @@ pub enum Expr {
     Int(i64),
     Float(f64),
     Bool(bool),
+    Unit,
     Str(String),
     Call {
         callee: Box<Expr>,

--- a/aethc_core/src/hir.rs
+++ b/aethc_core/src/hir.rs
@@ -84,6 +84,10 @@ pub enum Expr {
         value: bool,
         ty: Type,
     },
+    Unit {
+        id: NodeId,
+        ty: Type,
+    },
     Str {
         id: NodeId,
         value: String,
@@ -119,6 +123,7 @@ impl Expr {
             | Int { ty, .. }
             | Float { ty, .. }
             | Bool { ty, .. }
+            | Unit { ty, .. }
             | Str { ty, .. }
             | Call { ty, .. }
             | Unary { ty, .. }
@@ -128,15 +133,6 @@ impl Expr {
 
     /// Treat a block as Unit expression (placeholder until we have real value)
     pub fn from_block(b: Block) -> Self {
-        Expr::Call {
-            id: b.id,
-            callee: Box::new(Expr::Ident {
-                id: b.id,
-                name: "{block}".into(),
-                ty: Type::Unit,
-            }),
-            args: vec![],
-            ty: Type::Unit,
-        }
+        Expr::Unit { id: b.id, ty: Type::Unit }
     }
 }

--- a/aethc_core/src/parser.rs
+++ b/aethc_core/src/parser.rs
@@ -224,9 +224,14 @@ impl<'a> Parser<'a> {
             }
             TokenKind::LParen => {
                 self.bump();
-                let e = self.parse_expr(0);
-                self.expect(TokenKind::RParen);
-                e
+                if self.lookahead.kind == TokenKind::RParen {
+                    self.bump();
+                    ast::Expr::Unit
+                } else {
+                    let e = self.parse_expr(0);
+                    self.expect(TokenKind::RParen);
+                    e
+                }
             }
             _ => panic!("unexpected token {:?}", self.lookahead.kind),
         }

--- a/aethc_core/src/resolver.rs
+++ b/aethc_core/src/resolver.rs
@@ -244,6 +244,10 @@ impl Cx {
                 value: *b,
                 ty: Type::Bool,
             },
+            Unit => hir::Expr::Unit {
+                id,
+                ty: Type::Unit,
+            },
             Str(s) => hir::Expr::Str {
                 id,
                 value: s.clone(),


### PR DESCRIPTION
## Summary
- add `Unit` variant to AST Expr enum
- parse empty parens as `Expr::Unit`
- support `Expr::Unit` in HIR and resolver

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6860ede66e648327ab6d6ce2415afd9e