### PR TITLE
Add unit literal parsing and implicit return

### DIFF
--- a/aethc_core/src/lexer.rs
+++ b/aethc_core/src/lexer.rs
@@ -71,6 +71,7 @@ pub struct Token {
     pub span: Span,
 }
 
+#[derive(Clone)]
 pub struct Lexer<'a> {
     input: &'a str,
     pos: usize,


### PR DESCRIPTION
## Summary
- derive `Clone` for `Lexer` so the parser can peek ahead
- add `peek`/`peek_next` helpers in the parser
- detect `()` using lookahead and parse as `Unit`
- parse function bodies via new `parse_fn_body` that inserts an implicit `return ()` if missing

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6860f04eb1f483278c48b8c1f69a74af