### PR TITLE
Handle empty return as unit expression

### DIFF
--- a/aethc_core/src/resolver.rs
+++ b/aethc_core/src/resolver.rs
@@ -207,9 +207,16 @@ impl Cx {
                 }))
             }
             Expr(e) => Ok(hir::Stmt::Expr(self.lower_expr(e)?)),
-            Return(opt) => Ok(hir::Stmt::Return(
-                opt.as_ref().map(|e| self.lower_expr(e)).transpose()?,
-            )),
+            Return(opt) => {
+                let expr = match opt {
+                    Some(e) => self.lower_expr(e)?,
+                    None => hir::Expr::Unit {
+                        id: self.fresh(),
+                        ty: Type::Unit,
+                    },
+                };
+                Ok(hir::Stmt::Return(Some(expr)))
+            }
         }
     }
 

--- a/aethc_core/tests/resolve_unit_return.rs
+++ b/aethc_core/tests/resolve_unit_return.rs
@@ -1,0 +1,21 @@
+use aethc_core::{parser::Parser, resolver::resolve, hir, type_::Type};
+
+#[test]
+fn return_without_value_lowered_to_unit() {
+    let src = "fn main(){ return; }";
+    let (hir_mod, errs) = resolve(&Parser::new(src).parse_module());
+    assert!(errs.is_empty());
+
+    if let hir::Item::Fn(f) = &hir_mod.items[0] {
+        if let hir::Stmt::Return(Some(expr)) = &f.body.stmts[0] {
+            match expr {
+                hir::Expr::Unit { ty, .. } => assert_eq!(ty, &Type::Unit),
+                _ => panic!("expected unit expression"),
+            }
+        } else {
+            panic!("expected return statement");
+        }
+    } else {
+        panic!("expected function item");
+    }
+}


### PR DESCRIPTION
## Summary
- ensure resolver lowers `return;` to a unit expression
- add regression test for lowering of empty return

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6860f5432be8832786afc8b531608ee1