### PR TITLE
Add tests for unit expressions and borrow checker

### DIFF
--- a/aethc_core/tests/borrow_checker.rs
+++ b/aethc_core/tests/borrow_checker.rs
@@ -1,0 +1,10 @@
+use aethc_core::{borrowck::borrow_check, parser::Parser, resolver::resolve};
+
+#[test]
+fn copy_unit_is_ok() {
+    let src = "fn baz() { let a = (); let b = a; }";
+    let (hir_mod, res_errs) = resolve(&Parser::new(src).parse_module());
+    assert!(res_errs.is_empty());
+    let bc_errs = borrow_check(&hir_mod);
+    assert!(bc_errs.is_empty());
+}

--- a/aethc_core/tests/lexer.rs
+++ b/aethc_core/tests/lexer.rs
@@ -1,5 +1,13 @@
 use aethc_core::lexer::{Lexer, TokenKind, TokenKind::*};
 
+fn assert_tokens(src: &str, expected: &[TokenKind]) {
+    let mut lex = Lexer::new(src);
+    let kinds: Vec<TokenKind> = std::iter::from_fn(|| Some(lex.next_token().kind))
+        .take_while(|k| *k != Eof)
+        .collect();
+    assert_eq!(kinds, expected);
+}
+
 #[test]
 fn simple_tokens() {
     let src = r#"
@@ -35,5 +43,10 @@ fn bool_literals() {
         .collect();
 
     assert_eq!(kinds, vec![Bool(true), Bool(false)]);
+}
+
+#[test]
+fn unit_tokens() {
+    assert_tokens("()", &[LParen, RParen]);
 }
  

--- a/aethc_core/tests/parser.rs
+++ b/aethc_core/tests/parser.rs
@@ -1,8 +1,29 @@
 use aethc_core::parser::Parser;
+use aethc_core::ast;
+
+fn assert_ast(src: &str) -> ast::Expr {
+    // Wrap expression into a function body so we can parse it
+    let wrapped = format!("fn main() {{ {src}; }}");
+    let module = Parser::new(&wrapped).parse_module();
+    if let ast::Item::Function(f) = &module.items[0] {
+        if let ast::Stmt::Expr(e) = &f.body[0] {
+            return e.clone();
+        }
+    }
+    panic!("unexpected AST shape");
+}
 
 #[test]
 fn parse_hello() {
     let src = r#"fn main() { println("hi"); }"#;
     let module = Parser::new(src).parse_module();
     assert_eq!(module.items.len(), 1);
+}
+
+#[test]
+fn parse_unit_expr() {
+    let expr = assert_ast("()");
+    if !matches!(expr, ast::Expr::Unit) {
+        panic!("expected unit expr");
+    }
 }

--- a/aethc_core/tests/resolver.rs
+++ b/aethc_core/tests/resolver.rs
@@ -1,0 +1,13 @@
+use aethc_core::{parser::Parser, resolver::resolve};
+
+#[test]
+fn implicit_return_ok() {
+    let src = r#"
+        fn foo() {
+            let x = 1;
+        }
+    "#;
+    let module = Parser::new(src).parse_module();
+    let (_hir, errs) = resolve(&module);
+    assert!(errs.is_empty());
+}

--- a/aethc_core/tests/type_inference.rs
+++ b/aethc_core/tests/type_inference.rs
@@ -1,0 +1,9 @@
+use aethc_core::{parser::Parser, resolver::resolve};
+
+#[test]
+fn missing_return_error() {
+    let src = "fn bar() -> Int { }";
+    let (_hir, errs) = resolve(&Parser::new(src).parse_module());
+    assert_eq!(errs.len(), 1);
+    assert!(errs[0].msg.contains("expected Int"));
+}


### PR DESCRIPTION
## Summary
- extend lexer tests with a helper and new unit token check
- add parser test ensuring `()` parses to `Expr::Unit`
- cover implicit return handling in resolver
- verify missing return value is an error in new type inference test
- ensure borrow checker allows copying unit values

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6860fb8e79408327829307bc9486dbd9