### PR TITLE
Add implicit Int -> Float conversion

### DIFF
--- a/aethc_core/src/resolver.rs
+++ b/aethc_core/src/resolver.rs
@@ -83,6 +83,13 @@ impl Cx {
         self.scopes.iter().rev().find_map(|s| s.get(name))
     }
 
+    /// Check if a value of `actual` type can be implicitly converted to
+    /// `expected`. Currently the only allowed implicit conversion is
+    /// Int → Float.
+    fn compatible(&self, expected: &Type, actual: &Type) -> bool {
+        expected == actual || (expected == &Type::Float && actual == &Type::Int)
+    }
+
     /*──────── type lookup ───────*/
     fn resolve_type(&mut self, name: &str, span: Span) -> Result<Type, ResolveError> {
         match name {
@@ -226,7 +233,7 @@ impl Cx {
                     },
                 };
                 if let Some(expected) = &self.current_ret_ty {
-                    if expr.ty() != expected {
+                    if !self.compatible(expected, expr.ty()) {
                         return Err(ResolveError {
                             span: Span::default(),
                             msg: format!("expected {:?}, got {:?}", expected, expr.ty()),

--- a/aethc_core/tests/return_type.rs
+++ b/aethc_core/tests/return_type.rs
@@ -17,3 +17,18 @@ fn missing_return_value_error() {
     assert_eq!(errs.len(), 1);
     assert!(errs[0].msg.contains("expected Int"));
 }
+
+#[test]
+fn int_return_promoted_to_float() {
+    let src = "fn foo() -> Float { return 1; }";
+    let (_hir, errs) = resolve(&Parser::new(src).parse_module());
+    assert!(errs.is_empty());
+}
+
+#[test]
+fn float_to_int_error() {
+    let src = "fn foo() -> Int { return 1.0; }";
+    let (_hir, errs) = resolve(&Parser::new(src).parse_module());
+    assert_eq!(errs.len(), 1);
+    assert!(errs[0].msg.contains("expected Int"));
+}


### PR DESCRIPTION
## Summary
- allow implicit Int to Float conversion
- permit Int to Float in function return type checks
- test returning Int where Float is expected
- test that returning Float when Int expected is an error

## Testing
- `cargo test -p aethc_core`

------
https://chatgpt.com/codex/tasks/task_e_6860fcf605e083279a79c043adba6753