### PR TITLE
Implement simple work‑list type inference

### DIFF
--- a/aethc_core/src/infer_ctx.rs
+++ b/aethc_core/src/infer_ctx.rs
@@ -1,0 +1,129 @@
+use crate::lexer::Span;
+use std::collections::{HashMap, VecDeque};
+
+pub type TypeVarId = u32;
+
+#[derive(Clone, Debug)]
+pub struct TypeVar {
+    pub id: TypeVarId,
+    pub span: Span,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Ty {
+    Int,
+    Float,
+    Bool,
+    Str,
+    Unit,
+    Var(TypeVarId),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TvOrTy {
+    Var(TypeVarId),
+    Ty(Ty),
+}
+
+#[derive(Clone, Debug)]
+pub enum Constraint {
+    Eq(TvOrTy, TvOrTy),
+}
+
+pub struct InferCtx {
+    next_tv: TypeVarId,
+    pub vars: Vec<TypeVar>,
+    pub constraints: VecDeque<Constraint>,
+    pub subst: HashMap<TypeVarId, Ty>,
+}
+
+impl InferCtx {
+    pub fn new() -> Self {
+        Self { next_tv: 0, vars: Vec::new(), constraints: VecDeque::new(), subst: HashMap::new() }
+    }
+
+    pub fn fresh(&mut self, span: Span) -> TvOrTy {
+        let id = self.next_tv;
+        self.next_tv += 1;
+        self.vars.push(TypeVar { id, span });
+        TvOrTy::Var(id)
+    }
+
+    fn apply_ty(&self, ty: Ty) -> Ty {
+        match ty {
+            Ty::Var(v) => match self.subst.get(&v) {
+                Some(t) => self.apply_ty(t.clone()),
+                None => Ty::Var(v),
+            },
+            other => other,
+        }
+    }
+
+    pub fn apply(&self, x: TvOrTy) -> TvOrTy {
+        match x {
+            TvOrTy::Var(v) => match self.subst.get(&v) {
+                Some(t) => TvOrTy::Ty(self.apply_ty(t.clone())),
+                None => TvOrTy::Var(v),
+            },
+            TvOrTy::Ty(t) => TvOrTy::Ty(self.apply_ty(t)),
+        }
+    }
+
+    pub fn solve(&mut self) -> Result<(), String> {
+        while let Some(c) = self.constraints.pop_front() {
+            match c {
+                Constraint::Eq(a, b) => {
+                    let a_res = self.apply(a.clone());
+                    let b_res = self.apply(b.clone());
+                    if a_res == b_res {
+                        continue;
+                    }
+                    match (a_res, b_res) {
+                        (TvOrTy::Var(v), TvOrTy::Ty(ty)) | (TvOrTy::Ty(ty), TvOrTy::Var(v)) => {
+                            self.subst.insert(v, ty);
+                        }
+                        (TvOrTy::Var(v1), TvOrTy::Var(v2)) => {
+                            self.subst.insert(v1, Ty::Var(v2));
+                        }
+                        (TvOrTy::Ty(ty1), TvOrTy::Ty(ty2)) => {
+                            match Ty::unify(&ty1, &ty2) {
+                                Ok(t) => {
+                                    if t == Ty::Float {
+                                        self.subst_promote_float();
+                                    }
+                                }
+                                Err(_) => {
+                                    return Err(format!("type mismatch: {:?} vs {:?}", ty1, ty2));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn subst_promote_float(&mut self) {
+        for v in self.subst.values_mut() {
+            if matches!(v, Ty::Int) {
+                *v = Ty::Float;
+            }
+        }
+    }
+}
+
+impl Ty {
+    pub fn unify(a: &Ty, b: &Ty) -> Result<Ty, ()> {
+        use Ty::*;
+        match (a, b) {
+            (Int, Float) | (Float, Int) => Ok(Float),
+            (Int, Int) => Ok(Int),
+            (Float, Float) => Ok(Float),
+            (Bool, Bool) => Ok(Bool),
+            (Str, Str) => Ok(Str),
+            (Unit, Unit) => Ok(Unit),
+            _ => Err(()),
+        }
+    }
+}

--- a/aethc_core/src/lib.rs
+++ b/aethc_core/src/lib.rs
@@ -5,3 +5,5 @@ pub mod hir;
 pub mod parser;
 pub mod resolver;
 pub mod borrowck;
+pub mod infer_ctx;
+pub mod type_inference;

--- a/aethc_core/src/parser.rs
+++ b/aethc_core/src/parser.rs
@@ -329,3 +329,23 @@ impl<'a> Parser<'a> {
         }
     }
 }
+
+/*──────── utility parsers ───*/
+
+/// Parse a single expression from `src` using the same parser
+/// implementation that is used for full modules.
+pub fn parse_expr(src: &str) -> ast::Expr {
+    let mut p = Parser::new(src);
+    let expr = p.parse_expr(0);
+    assert!(p.lookahead.kind == TokenKind::Eof, "trailing input after expression");
+    expr
+}
+
+/// Parse a single statement from `src`. Currently only a subset of
+/// statements used in tests is supported.
+pub fn parse_stmt(src: &str) -> ast::Stmt {
+    let mut p = Parser::new(src);
+    let stmt = p.parse_stmt();
+    assert!(p.lookahead.kind == TokenKind::Eof, "trailing input after statement");
+    stmt
+}

--- a/aethc_core/src/type_inference.rs
+++ b/aethc_core/src/type_inference.rs
@@ -1,0 +1,69 @@
+use crate::ast::{self, BinOp};
+use crate::lexer::Span;
+use crate::parser;
+use crate::infer_ctx::{InferCtx, TvOrTy, Constraint, Ty};
+
+fn gen_constraints(expr: &ast::Expr, cx: &mut InferCtx) -> TvOrTy {
+    use ast::Expr::*;
+    match expr {
+        Int(_) => {
+            let tv = cx.fresh(Span::default());
+            cx.constraints.push_back(Constraint::Eq(tv.clone(), TvOrTy::Ty(Ty::Int)));
+            tv
+        }
+        Float(_) => {
+            let tv = cx.fresh(Span::default());
+            cx.constraints.push_back(Constraint::Eq(tv.clone(), TvOrTy::Ty(Ty::Float)));
+            tv
+        }
+        Bool(_) => {
+            let tv = cx.fresh(Span::default());
+            cx.constraints.push_back(Constraint::Eq(tv.clone(), TvOrTy::Ty(Ty::Bool)));
+            tv
+        }
+        Str(_) => {
+            let tv = cx.fresh(Span::default());
+            cx.constraints.push_back(Constraint::Eq(tv.clone(), TvOrTy::Ty(Ty::Str)));
+            tv
+        }
+        Unit => {
+            let tv = cx.fresh(Span::default());
+            cx.constraints.push_back(Constraint::Eq(tv.clone(), TvOrTy::Ty(Ty::Unit)));
+            tv
+        }
+        Binary { op, lhs, rhs } => {
+            let l = gen_constraints(lhs, cx);
+            let r = gen_constraints(rhs, cx);
+            let res = cx.fresh(Span::default());
+            cx.constraints.push_back(Constraint::Eq(l.clone(), r.clone()));
+            match op {
+                BinOp::Plus | BinOp::Minus | BinOp::Star | BinOp::Slash => {
+                    cx.constraints.push_back(Constraint::Eq(res.clone(), l));
+                }
+                BinOp::EqEq | BinOp::NotEq | BinOp::Lt | BinOp::Le | BinOp::Gt | BinOp::Ge => {
+                    cx.constraints.push_back(Constraint::Eq(res.clone(), TvOrTy::Ty(Ty::Bool)));
+                }
+                _ => {}
+            }
+            res
+        }
+        Unary { expr, .. } => gen_constraints(expr, cx),
+        Ident(_) | Call { .. } => cx.fresh(Span::default()),
+    }
+}
+
+pub fn infer_expr(expr: &ast::Expr) -> Result<Ty, String> {
+    let mut cx = InferCtx::new();
+    let root = gen_constraints(expr, &mut cx);
+    cx.solve()?;
+    match cx.apply(root) {
+        TvOrTy::Ty(t) => Ok(t),
+        TvOrTy::Var(_) => Err("cannot infer type".to_string()),
+    }
+}
+
+/// Convenience wrapper for tests: parse and infer a single expression.
+pub fn infer_str(src: &str) -> Result<Ty, String> {
+    let expr = parser::parse_expr(src);
+    infer_expr(&expr)
+}

--- a/aethc_core/tests/worklist_infer.rs
+++ b/aethc_core/tests/worklist_infer.rs
@@ -1,0 +1,34 @@
+use aethc_core::{type_inference as infer, infer_ctx::Ty};
+
+fn assert_type(src: &str, expected: Ty) {
+    let ty = infer::infer_str(src).expect("inference failed");
+    assert_eq!(ty, expected);
+}
+
+fn assert_ok(expr: &str) {
+    infer::infer_str(expr).expect("expected success");
+}
+
+fn assert_err(expr: &str) {
+    assert!(infer::infer_str(expr).is_err());
+}
+
+#[test]
+fn promotion() {
+    assert_type("1 + 2.0", Ty::Float);
+}
+
+#[test]
+fn eq_bool() {
+    assert_type("1 == 2", Ty::Bool);
+}
+
+#[test]
+fn lit_ok() {
+    assert_ok("42");
+}
+
+#[test]
+fn bool_plus_int_err() {
+    assert_err("true + 1");
+}


### PR DESCRIPTION
## Summary
- add `infer_ctx` with basic type variables and constraints
- implement worklist-based inference for literals and binary ops
- expose helpers to parse single expressions/stmt
- add regression tests exercising the new inference

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6861074361388327975915cee599dc45