### PR TITLE
Implement mutable shadowing and move semantics

### DIFF
--- a/aethc_core/src/type_.rs
+++ b/aethc_core/src/type_.rs
@@ -52,4 +52,8 @@ impl Type {
             _ => Err(()),
         }
     }
+
+    pub fn is_copy(&self) -> bool {
+        matches!(self, Type::Int | Type::Float | Type::Bool | Type::Unit)
+    }
 }

--- a/aethc_core/tests/borrow_tests.rs
+++ b/aethc_core/tests/borrow_tests.rs
@@ -1,0 +1,36 @@
+use aethc_core::{parser::Parser, resolver::resolve, borrow::check_fn_body};
+
+#[test]
+fn ok() {
+    let src = r#"fn main(){ let mut x = 1; let x = 2; }"#;
+    let (hir_mod, res_errs) = resolve(&Parser::new(src).parse_module());
+    assert!(res_errs.is_empty());
+    if let aethc_core::hir::Item::Fn(f) = &hir_mod.items[0] {
+        let errs = check_fn_body(&f.body);
+        assert!(errs.is_empty());
+    }
+}
+
+#[test]
+fn bad() {
+    let src = r#"fn main(){ let x = 1; let x = 2; }"#;
+    let (hir_mod, res_errs) = resolve(&Parser::new(src).parse_module());
+    assert_eq!(res_errs.len(), 1);
+    assert!(res_errs[0].msg.contains("cannot redeclare"));
+    if let Some(aethc_core::hir::Item::Fn(f)) = hir_mod.items.get(0) {
+        let errs = check_fn_body(&f.body);
+        assert!(errs.is_empty());
+    }
+}
+
+#[test]
+fn bad_move() {
+    let src = r#"fn main(){ let s = "abc"; let t = s; let u = s; }"#;
+    let (hir_mod, res_errs) = resolve(&Parser::new(src).parse_module());
+    assert!(res_errs.is_empty());
+    if let aethc_core::hir::Item::Fn(f) = &hir_mod.items[0] {
+        let errs = check_fn_body(&f.body);
+        assert_eq!(errs.len(), 1);
+        assert!(matches!(errs[0].kind, aethc_core::borrow::BorrowErrorKind::DoubleMove | aethc_core::borrow::BorrowErrorKind::UseAfterMove));
+    }
+}

--- a/aethc_core/tests/borrowck_ok_err.rs
+++ b/aethc_core/tests/borrowck_ok_err.rs
@@ -15,7 +15,7 @@ fn borrowck_detects_reassignment() {
 
     // Resolver should report a duplicate-name error
     assert_eq!(res_errs.len(), 1);
-    assert!(res_errs[0].msg.contains("already defined"));
+    assert!(res_errs[0].msg.contains("cannot redeclare"));
 
     // Borrow-checker sees no errors when resolve already failed
     let bc_errs = borrow_check(&hir_mod);

--- a/aethc_core/tests/resolve_dup_name.rs
+++ b/aethc_core/tests/resolve_dup_name.rs
@@ -12,7 +12,7 @@ fn duplicate_name_error() {
 
     // Resolver should report an error for the duplicate name
     assert_eq!(res_errs.len(), 1);
-    assert!(res_errs[0].msg.contains("already defined"));
+    assert!(res_errs[0].msg.contains("cannot redeclare"));
 
     // Borrow checker sees no errors when resolve already failed
     let bc_errs = borrow_check(&hir_mod);


### PR DESCRIPTION
## Summary
- allow shadowing previous `let` only when the previous binding is mutable
- track mutability in resolver symbols and check in assignments
- implement `Type::is_copy` helper
- extend borrow checker with move semantics for `Str`
- add tests for move semantics and mutable shadowing

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6861191b136c8327928a43bf372c1d09