### PR TITLE
Add LLVM IR codegen skeleton

### DIFF
--- a/aethc_cli/src/main.rs
+++ b/aethc_cli/src/main.rs
@@ -1,18 +1,71 @@
-use std::{env, fs};
+use std::{env, fs, process::Command};
 
 fn main() {
-    // expect: aethc parse <file>
     let mut args = env::args().skip(1);
-    if args.next().as_deref() != Some("parse") {
-        eprintln!("usage: aethc parse <file>");
+    let cmd = args.next().unwrap_or_else(|| {
+        eprintln!("usage: aethc <parse|build> <file> [-o <out>]");
         std::process::exit(1);
+    });
+
+    match cmd.as_str() {
+        "parse" => {
+            let path = args
+                .next()
+                .unwrap_or_else(|| {
+                    eprintln!("missing <file>");
+                    std::process::exit(1)
+                });
+            let src = fs::read_to_string(&path).expect("failed to read file");
+            let module = aethc_core::parser::Parser::new(&src).parse_module();
+            println!("{:#?}", module);
+        }
+        "build" => {
+            let path = args
+                .next()
+                .unwrap_or_else(|| {
+                    eprintln!("missing <file>");
+                    std::process::exit(1)
+                });
+            let mut out = "a.out".to_string();
+            if args.next().as_deref() == Some("-o") {
+                out = args
+                    .next()
+                    .unwrap_or_else(|| {
+                        eprintln!("missing output after -o");
+                        std::process::exit(1)
+                    });
+            }
+            let src = fs::read_to_string(&path).expect("failed to read file");
+            let ast_mod = aethc_core::parser::Parser::new(&src).parse_module();
+            let (hir_mod, errs) = aethc_core::resolver::resolve(&ast_mod);
+            if !errs.is_empty() {
+                for e in errs {
+                    eprintln!("{:?}", e);
+                }
+                std::process::exit(1);
+            }
+            let mir = match &hir_mod.items[0] {
+                aethc_core::hir::Item::Fn(f) => aethc_core::mir::lower_fn(f),
+                _ => {
+                    eprintln!("expected a function");
+                    std::process::exit(1);
+                }
+            };
+            let mut llcx = aethc_core::codegen::new_module("app");
+            aethc_core::codegen::codegen_fn(&mut llcx, "main", &mir);
+            let bc_path = "temp.bc";
+            aethc_core::codegen::write_ir(&llcx, bc_path);
+            let _ = Command::new("clang")
+                .arg("-O0")
+                .arg("-no-pie")
+                .arg(bc_path)
+                .arg("-o")
+                .arg(&out)
+                .status();
+        }
+        _ => {
+            eprintln!("usage: aethc <parse|build> <file> [-o <out>]");
+            std::process::exit(1);
+        }
     }
-    let path = args
-        .next()
-        .unwrap_or_else(|| { eprintln!("missing <file>"); std::process::exit(1) });
-
-    let src = fs::read_to_string(&path).expect("failed to read file");
-    let module = aethc_core::parser::Parser::new(&src).parse_module();
-
-    println!("{:#?}", module);
 }

--- a/aethc_core/Cargo.toml
+++ b/aethc_core/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+inkwell = "0.2"

--- a/aethc_core/src/codegen.rs
+++ b/aethc_core/src/codegen.rs
@@ -1,0 +1,239 @@
+use std::collections::HashMap;
+
+use inkwell::{
+    builder::Builder,
+    context::Context,
+    module::Module,
+    types::{BasicTypeEnum},
+    values::{BasicValueEnum, FunctionValue},
+    AddressSpace,
+};
+
+use crate::mir::{
+    BasicBlock, BinOp, Constant, MirBody, MirType, Operand, Rvalue, Statement,
+    Terminator, TempId, RET_TEMP,
+};
+
+pub struct LlvmCtx<'ctx> {
+    pub context: Context,
+    pub module: Module<'ctx>,
+    pub builder: Builder<'ctx>,
+}
+
+pub fn new_module(name: &str) -> LlvmCtx {
+    let ctx = Context::create();
+    let module = ctx.create_module(name);
+    let builder = ctx.create_builder();
+    LlvmCtx {
+        context: ctx,
+        module,
+        builder,
+    }
+}
+
+impl<'ctx> LlvmCtx<'ctx> {
+    fn ll_ty(&self, ty: &MirType) -> BasicTypeEnum<'ctx> {
+        match ty {
+            MirType::Int => self.context.i32_type().into(),
+            MirType::Float => self.context.f64_type().into(),
+            MirType::Bool => self.context.bool_type().into(),
+            MirType::Str => self
+                .context
+                .i8_type()
+                .ptr_type(AddressSpace::Generic)
+                .into(),
+            MirType::Unit => self.context.void_type().into(),
+        }
+    }
+}
+
+pub fn codegen_fn<'ctx>(llcx: &mut LlvmCtx<'ctx>, name: &str, mir: &MirBody) {
+    let ret_ty = llcx.ll_ty(&mir.ret_ty);
+    let fn_ty = match ret_ty {
+        BasicTypeEnum::VoidType(v) => v.fn_type(&[], false),
+        _ => ret_ty.fn_type(&[], false),
+    };
+    let func = llcx.module.add_function(name, fn_ty, None);
+
+    let entry_bb = llcx.context.append_basic_block(func, "bb0");
+    llcx.builder.position_at_end(entry_bb);
+
+    let mut temps: HashMap<TempId, BasicValueEnum<'ctx>> = HashMap::new();
+
+    lower_block(llcx, &mir.blocks[0], func, &mut temps, &mir.blocks, &mir.ret_ty);
+}
+
+fn get_or_create_bb<'ctx>(
+    llcx: &mut LlvmCtx<'ctx>,
+    func: FunctionValue<'ctx>,
+    id: u32,
+) -> inkwell::basic_block::BasicBlock<'ctx> {
+    for bb in func.get_basic_blocks() {
+        if bb.get_name().to_str() == Ok(format!("bb{}", id)) {
+            return bb;
+        }
+    }
+    llcx.context.append_basic_block(func, &format!("bb{}", id))
+}
+
+fn succ_blocks(term: &Terminator) -> Vec<u32> {
+    match term {
+        Terminator::Goto(id) => vec![*id],
+        Terminator::CondBranch { then_bb, else_bb, .. } => vec![*then_bb, *else_bb],
+        _ => Vec::new(),
+    }
+}
+
+fn lower_block<'ctx>(
+    llcx: &mut LlvmCtx<'ctx>,
+    bb: &BasicBlock,
+    func: FunctionValue<'ctx>,
+    temps: &mut HashMap<TempId, BasicValueEnum<'ctx>>,
+    all: &[BasicBlock],
+    ret_ty: &MirType,
+) {
+    for stmt in &bb.stmts {
+        match stmt {
+            Statement::Assign { dst, rv } => {
+                let val = lower_rvalue(llcx, rv, temps);
+                temps.insert(*dst, val);
+            }
+            _ => {}
+        }
+    }
+
+    match &bb.term {
+        Terminator::Return => {
+            if *ret_ty == MirType::Unit {
+                llcx.builder.build_return(None);
+            } else {
+                let ret_val = temps.get(&RET_TEMP).expect("ret temp");
+                llcx.builder.build_return(Some(ret_val));
+            }
+        }
+        Terminator::Goto(id) => {
+            let l_bb = get_or_create_bb(llcx, func, *id);
+            llcx.builder.build_unconditional_branch(l_bb);
+        }
+        Terminator::CondBranch {
+            cond,
+            then_bb,
+            else_bb,
+        } => {
+            let cond_val = lower_operand(llcx, cond, temps).into_int_value();
+            let then_ll = get_or_create_bb(llcx, func, *then_bb);
+            let else_ll = get_or_create_bb(llcx, func, *else_bb);
+            llcx
+                .builder
+                .build_conditional_branch(cond_val, then_ll, else_ll);
+        }
+    }
+
+    for succ in succ_blocks(&bb.term) {
+        if !func
+            .get_basic_blocks()
+            .iter()
+            .any(|b| b.get_name().to_str() == Ok(format!("bb{}", succ)))
+        {
+            let new_bb = llcx.context.append_basic_block(func, &format!("bb{}", succ));
+            llcx.builder.position_at_end(new_bb);
+            lower_block(llcx, &all[succ as usize], func, temps, all, ret_ty);
+        }
+    }
+}
+
+fn lower_operand<'ctx>(
+    llcx: &LlvmCtx<'ctx>,
+    op: &Operand,
+    temps: &HashMap<TempId, BasicValueEnum<'ctx>>,
+) -> BasicValueEnum<'ctx> {
+    match op {
+        Operand::Const(c) => match c {
+            Constant::Int(i) => llcx
+                .context
+                .i32_type()
+                .const_int(*i as u64, true)
+                .into(),
+            Constant::Float(f) => llcx.context.f64_type().const_float(*f).into(),
+            Constant::Bool(b) => llcx
+                .context
+                .bool_type()
+                .const_int(*b as u64, false)
+                .into(),
+            Constant::Str(_) => todo!("string literal"),
+            Constant::Unit => panic!("unit is never a value"),
+        },
+        Operand::Temp(t) => *temps.get(t).expect("temp"),
+        Operand::Var(v) => {
+            let ptr = *temps.get(v).expect("var ptr");
+            llcx.builder.build_load(ptr.into_pointer_value(), "varload")
+        }
+    }
+}
+
+fn lower_rvalue<'ctx>(
+    llcx: &mut LlvmCtx<'ctx>,
+    rv: &Rvalue,
+    temps: &HashMap<TempId, BasicValueEnum<'ctx>>,
+) -> BasicValueEnum<'ctx> {
+    match rv {
+        Rvalue::Use(op) => lower_operand(llcx, op, temps),
+        Rvalue::BinaryOp { op, lhs, rhs } => {
+            let l = lower_operand(llcx, lhs, temps);
+            let r = lower_operand(llcx, rhs, temps);
+            match op {
+                BinOp::Plus => {
+                    if l.is_float_value() || r.is_float_value() {
+                        let l_val = if l.is_int_value() {
+                            llcx
+                                .builder
+                                .build_signed_int_to_float(
+                                    l.into_int_value(),
+                                    llcx.context.f64_type(),
+                                    "sitofp",
+                                )
+                                .into()
+                        } else {
+                            l
+                        };
+                        let r_val = if r.is_int_value() {
+                            llcx
+                                .builder
+                                .build_signed_int_to_float(
+                                    r.into_int_value(),
+                                    llcx.context.f64_type(),
+                                    "sitofp",
+                                )
+                                .into()
+                        } else {
+                            r
+                        };
+                        llcx
+                            .builder
+                            .build_float_add(
+                                l_val.into_float_value(),
+                                r_val.into_float_value(),
+                                "faddtmp",
+                            )
+                            .into()
+                    } else {
+                        llcx
+                            .builder
+                            .build_int_add(
+                                l.into_int_value(),
+                                r.into_int_value(),
+                                "iaddtmp",
+                            )
+                            .into()
+                    }
+                }
+                _ => todo!("other binops"),
+            }
+        }
+        _ => todo!("unary, call"),
+    }
+}
+
+pub fn write_ir(llcx: &LlvmCtx, path: &str) {
+    llcx.module.print_to_file(path).unwrap();
+}

--- a/aethc_core/src/lib.rs
+++ b/aethc_core/src/lib.rs
@@ -10,3 +10,4 @@ pub mod infer_ctx;
 pub mod type_inference;
 pub mod test_harness;
 pub mod mir;
+pub mod codegen;

--- a/aethc_core/tests/codegen_ir.rs
+++ b/aethc_core/tests/codegen_ir.rs
@@ -1,0 +1,28 @@
+use aethc_core::{
+    parser::Parser,
+    resolver::resolve,
+    mir::{self},
+    codegen::{new_module, codegen_fn},
+};
+
+fn build_dummy_add() -> mir::MirBody {
+    let src = "fn add() -> Int { return 3 + 4; }";
+    let module = Parser::new(src).parse_module();
+    let (hir_mod, errs) = resolve(&module);
+    assert!(errs.is_empty());
+    if let aethc_core::hir::Item::Fn(f) = &hir_mod.items[0] {
+        mir::lower_fn(f)
+    } else {
+        panic!("expected function");
+    }
+}
+
+#[test]
+fn simple_add() {
+    let mir = build_dummy_add();
+    let mut llcx = new_module("test");
+    codegen_fn(&mut llcx, "add", &mir);
+    let txt = llcx.module.print_to_string().to_string();
+    assert!(txt.contains("define i32 @add()"));
+    assert!(txt.contains("add i32"));
+}


### PR DESCRIPTION
## Summary
- add an inkwell based codegen module for lowering MIR to LLVM IR
- expose the module in the library
- integrate a `build` command in CLI that emits LLVM IR and links with clang
- create a simple codegen test

## Testing
- `cargo test --quiet` *(fails: failed to get `inkwell` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68612539aeac832787f4196f63e2878c