### PR TITLE
Upgrade inkwell

### DIFF
--- a/aethc_cli/Cargo.toml
+++ b/aethc_cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 aethc_core = { path = "../aethc_core" }
 clap = { version = "4", features = ["derive"] }
 ariadne = "0.4"
-inkwell = "0.2"
+inkwell = "0.4"
 
 [build-dependencies]
 cc = "1.0"

--- a/aethc_core/Cargo.toml
+++ b/aethc_core/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-inkwell = "0.2"
+inkwell = "0.4"


### PR DESCRIPTION
## Summary
- bump `inkwell` from 0.2 to 0.4 in `aethc_core`
- keep CLI in sync

## Testing
- `cargo update` *(fails: failed to download from `https://index.crates.io`)*
- `cargo test --quiet` *(fails: network access to crates.io blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68618b26c60483279ac84c10c5a624aa