### PR TITLE
Add Rust toolchain config

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+version = "1.75.0"


### PR DESCRIPTION
## Summary
- specify Rust toolchain with stable channel and version 1.75.0

## Testing
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68618e2fb884832797d5545b26a27b8a