### PR TITLE
Fix BinOp import in codegen

### DIFF
--- a/aethc_core/src/codegen.rs
+++ b/aethc_core/src/codegen.rs
@@ -10,9 +10,10 @@ use inkwell::{
 };
 
 use crate::mir::{
-    BasicBlock, BinOp, Constant, MirBody, MirType, Operand, Rvalue, Statement,
+    BasicBlock, Constant, MirBody, MirType, Operand, Rvalue, Statement,
     Terminator, TempId, RET_TEMP,
 };
+use crate::hir::BinOp;
 
 pub struct LlvmCtx<'ctx> {
     pub context: Context,


### PR DESCRIPTION
## Summary
- switch BinOp import from MIR to HIR
- leave codegen logic untouched

## Testing
- `cargo test --quiet` *(fails: failed to get `inkwell` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_686198eae2b483278458712d662a7497