### PR TITLE
Fix AddressSpace API usage

### DIFF
--- a/aethc_core/src/codegen.rs
+++ b/aethc_core/src/codegen.rs
@@ -26,7 +26,7 @@ pub fn new_module(name: &str) -> LlvmCtx {
     let builder = ctx.create_builder();
 
     let i32_ty = ctx.i32_type();
-    let i8_ptr = ctx.i8_type().ptr_type(AddressSpace::Generic);
+    let i8_ptr = ctx.i8_type().ptr_type(AddressSpace::default());
 
     module.add_function(
         "aethc_print_int",
@@ -56,7 +56,7 @@ impl<'ctx> LlvmCtx<'ctx> {
             MirType::Str => self
                 .context
                 .i8_type()
-                .ptr_type(AddressSpace::Generic)
+                .ptr_type(AddressSpace::default())
                 .into(),
             MirType::Unit => unreachable!("unit type has no LLVM equivalent"),
         }


### PR DESCRIPTION
## Summary
- update new_module to use `AddressSpace::default()`
- use the same AddressSpace constant in `ll_ty`

## Testing
- `cargo check -p aethc_core --offline` *(fails: no matching package named `ariadne` found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a8da0f7083278afc74988a26c027