### PR TITLE
Fix CLI build issues

### DIFF
--- a/aethc_cli/src/main.rs
+++ b/aethc_cli/src/main.rs
@@ -115,7 +115,7 @@ fn run_full_frontend(path: &PathBuf, emit: Option<&str>) -> Result<LlvmModule<'s
     }
 
     // Codegen
-    let mut llcx = aethc_core::codegen::new_module("app");
+    let mut llcx = aethc_core::codegen::LlvmCtx::new("app");
     aethc_core::codegen::codegen_fn(&mut llcx, "main", &mir);
 
     if let Some("llvm") = emit {
@@ -127,11 +127,12 @@ fn run_full_frontend(path: &PathBuf, emit: Option<&str>) -> Result<LlvmModule<'s
 }
 
 fn link_with_clang(bc: &std::path::Path, out: &std::path::Path) {
+    let target_dir = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".into());
     let status = std::process::Command::new("clang")
         .arg("-O0")
         .arg(bc)
         .arg("-L")
-        .arg(format!("{}/debug", env!("CARGO_TARGET_DIR")))
+        .arg(format!("{target_dir}/debug"))
         .arg("-laethc_runtime")
         .arg("-o")
         .arg(out)

--- a/aethc_core/src/codegen.rs
+++ b/aethc_core/src/codegen.rs
@@ -27,6 +27,36 @@ pub struct LlvmContext {
     context: Context,
 }
 
+impl LlvmCtx<'static> {
+    /// Create a new LLVM context, module and builder with built-in functions.
+    pub fn new(name: &str) -> Self {
+        let context = Box::leak(Box::new(Context::create()));
+        let module = context.create_module(name);
+        let builder = context.create_builder();
+
+        let i32_ty = context.i32_type();
+        let i8_ptr = context.i8_type().ptr_type(AddressSpace::default());
+
+        module.add_function(
+            "aethc_print_int",
+            context.void_type().fn_type(&[i32_ty.into()], false),
+            None,
+        );
+
+        module.add_function(
+            "aethc_print_str",
+            context.void_type().fn_type(&[i8_ptr.into()], false),
+            None,
+        );
+
+        Self {
+            context,
+            module,
+            builder,
+        }
+    }
+}
+
 impl LlvmContext {
     pub fn new() -> Self {
         Self {

--- a/aethc_core/tests/codegen_ir.rs
+++ b/aethc_core/tests/codegen_ir.rs
@@ -2,7 +2,7 @@ use aethc_core::{
     parser::Parser,
     resolver::resolve,
     mir::{self},
-    codegen::{new_module, codegen_fn},
+    codegen::{LlvmCtx, codegen_fn},
 };
 
 fn build_dummy_add() -> mir::MirBody {
@@ -20,7 +20,7 @@ fn build_dummy_add() -> mir::MirBody {
 #[test]
 fn simple_add() {
     let mir = build_dummy_add();
-    let mut llcx = new_module("test");
+    let mut llcx = LlvmCtx::new("test");
     codegen_fn(&mut llcx, "add", &mir);
     let txt = llcx.module.print_to_string().to_string();
     assert!(txt.contains("define i32 @add()"));


### PR DESCRIPTION
## Summary
- use `LlvmCtx::new` for codegen setup
- locate runtime libs using `std::env::var`
- expose new codegen constructor for tests

## Testing
- `cargo build` *(fails: failed to download crates)*
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6861b82f9ed48327a726ce49cbebe0d5